### PR TITLE
Blacklist Improvements/Fixes

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -52,9 +52,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Mod(modid = PECore.MODID, name = PECore.MODNAME, version = PECore.VERSION, acceptedMinecraftVersions = "[1.12,]", dependencies = PECore.DEPS, updateJSON = PECore.UPDATE_JSON)
 @Mod.EventBusSubscriber(modid = PECore.MODID)
@@ -77,6 +75,8 @@ public class PECore
 	
 	@SidedProxy(clientSide = "moze_intel.projecte.proxies.ClientProxy", serverSide = "moze_intel.projecte.proxies.ServerProxy")
 	public static IProxy proxy;
+	public static HashSet<String> externalTEBlacklist = new HashSet<>();
+	public static HashSet<String> externalBlockBlacklist = new HashSet<>();
 
 	public static final List<String> uuids = new ArrayList<>();
 
@@ -147,6 +147,18 @@ public class PECore
 		fixer.registerWalker(FixTypes.BLOCK_ENTITY, new CapInventoryWalker(
 				ImmutableSet.of(RelayMK1Tile.class, RelayMK2Tile.class, RelayMK3Tile.class),
 				"Input", "Output"));
+
+		initializeExternalBlacklist();
+
+	}
+
+	private void initializeExternalBlacklist()
+	{
+		String[] timeWatchTEBlacklist = ProjectEConfig.effects.timeWatchTEBlacklist;
+		externalTEBlacklist = new HashSet<>(Arrays.asList(timeWatchTEBlacklist));
+
+		String[] timeWatchBlockBlacklist = ProjectEConfig.effects.timeWatchBlockBlacklist;
+		externalBlockBlacklist = new HashSet<>(Arrays.asList(timeWatchBlockBlacklist));
 	}
 
 	@EventHandler

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -5,6 +5,7 @@ import moze_intel.projecte.PECore;
 import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.gameObjs.items.TimeWatch;
 
+import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
 import net.minecraft.block.*;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -372,23 +373,40 @@ public final class WorldHelper
 		for (BlockPos pos : getPositionsFromBox(bBox))
 		{
 			TileEntity tile = world.getTileEntity(pos);
-			if (tile != null)
+
+			if (tile != null && !(tile instanceof DMPedestalTile) && !isBlacklisted(tile))
 			{
-				ResourceLocation registryName = tile.getBlockType().getRegistryName();
-				ResourceLocation tileName = TileEntity.getKey(tile.getClass());
-				if (registryName != null && tileName != null)
-				{
-					String combinedName = registryName.getNamespace() + ":" + tileName;
-					if (!TimeWatch.internalBlacklist.contains(tile.getClass().getName()) && !Arrays.asList(ProjectEConfig.effects.timeWatchTEBlacklist).contains(combinedName))
-					{
-						list.add(tile);
-					}
-				}
+				list.add(tile);
 			}
 		}
 
 		return list;
 	}
+
+	public static boolean isBlacklisted(TileEntity tile) {
+		Class tileClass = tile.getClass();
+		ResourceLocation registryName = tile.getBlockType().getRegistryName();
+		ResourceLocation tileName = TileEntity.getKey(tileClass);
+
+		if (tileClass.getName().startsWith("mrtjp.projectred") || tileClass.getName().contains("TileMultipart")) {
+			return true;
+		}
+
+		if (registryName != null && tileName != null) {
+			String combinedName = registryName.getNamespace() + ":" + tileName;
+			return TimeWatch.internalBlacklist.contains(tileClass.getName()) || PECore.externalTEBlacklist.contains(combinedName);
+		}
+
+		return false;
+	}
+
+	public static boolean isBlacklisted(Block block) {
+		Class blockClass = block.getClass();
+
+		return TimeWatch.internalBlacklist.contains(blockClass.getName()) || PECore.externalBlockBlacklist.contains(block.getRegistryName().toString());
+	}
+
+
 
 	/**
 	 * Gravitates an entity, vanilla xp orb style, towards a position


### PR DESCRIPTION
- Fix a stack overflow exception caused by the DMPedestalTile not being skipped.
- Move the blacklist logic to dedicated methods and use HashSets that are initialised on server start instead of converting to a list on every iteration. 
- Blacklist Project Red. 
- Prevent double speedup of Tile Entities. These should only be sped up once, inside speedUpTileEntities, instead of twice, which can sometimes result in unexpected behaviour.

These changes have been tested on our Tekkit 2 development test server, across a wide range of player bases, and have presented no issue.

Project Red validation could be better, but it works. Please feel free to adjust as you need to.